### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,10 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
+  def index
+    @items = Item.includes(:user).order("created_at DESC")
+  end
+
   def new
     @item = Item.new
   end

--- a/app/views/items/_items.html.erb
+++ b/app/views/items/_items.html.erb
@@ -1,0 +1,27 @@
+<li class='list'>
+  <%= link_to "#" do %>
+    <div class='item-img-content'>
+      <%= image_tag items.image, class: "item-img" %>
+
+    <%# <% if items.user_item.present?%>
+    <%# 購入機能を実装後にuser_itemsテーブルを作って、itemsに関連したuser_itemのレコードが存在する場合に表示されるようにしたい。 %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+    <%# <% end %>
+
+    </div>
+    <div class='item-info'>
+      <h3 class='item-name'>
+        <%= items.name %>
+      </h3>
+      <div class='item-price'>
+        <span><%= items.price %>円<br>(税込み)</span>
+        <div class='star-btn'>
+          <%= image_tag "star.png", class:"star-icon" %>
+          <span class='star-count'>0</span>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</li>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,59 +123,32 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outの表示 %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if @items.empty? %>
+        <%# 商品がない場合のダミー %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合のダミー %>
+          <% end %>
+        </li>
+        <%# //商品がない場合のダミー %>
+      <% else %>
+        <%= render partial: 'items', collection: @items %>
+      <% end %>
     </ul>
   </div>
   <%# //商品一覧 %>


### PR DESCRIPTION
## What
商品一覧表示機能を実装しました。
一覧表示機能は、partialで切り離して実装しました。
また、ダミー画像との切り替えは、if文でempty?メソッドを利用してitemsモデルのレコードの有無を確認して分岐する仕様にしました。

しかし、**購入済みの場合Sold Outが表示される機能は、購入機能を実装していないのでまだ実装できていません。**

## 動作確認
### ログインしていない場合の一覧表示
https://gyazo.com/18da8251fa1cecb3b07001062230e57e
### ログインしている場合の一覧表示
https://gyazo.com/fea7a355c59e8c05ad08ea22cadd4a76
